### PR TITLE
A2J-186 Move Configuration to Common Library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,6 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
 
@@ -83,14 +78,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-oauth2-client</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-oauth2-resource-server</artifactId>
-            <version>5.7.1</version>
+            <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,19 +13,26 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.6.7</version>
+        <version>2.7.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
+        <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <spring-cloud.version>2021.0.2</spring-cloud.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
 
         <dependency>
@@ -49,7 +56,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.8.5</version>
+            <version>1.9.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
@@ -77,11 +84,50 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-resource-server</artifactId>
+            <version>5.7.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>0.9.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>pinpoint</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.16.60</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <reporting>
         <plugins>
             <plugin>

--- a/src/main/java/com/smoothstack/common/CommonApplication.java
+++ b/src/main/java/com/smoothstack/common/CommonApplication.java
@@ -1,10 +1,9 @@
 package com.smoothstack.common;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication()
 public class CommonApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/smoothstack/common/configuration/AwsPinpointConfiguration.java
+++ b/src/main/java/com/smoothstack/common/configuration/AwsPinpointConfiguration.java
@@ -1,0 +1,17 @@
+package com.smoothstack.common.configuration;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("cloud.aws.pinpoint")
+public class AwsPinpointConfiguration {
+    String appId;
+    String accessKeyId;
+    String secretKey;
+    String emailFrom;
+    String emailCharset;
+    String smsFrom;
+    String smsMsgType;
+    String smsSenderId;
+}

--- a/src/main/java/com/smoothstack/common/configuration/JwtConfiguration.java
+++ b/src/main/java/com/smoothstack/common/configuration/JwtConfiguration.java
@@ -1,0 +1,33 @@
+package com.smoothstack.common.configuration;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.security.converter.RsaKeyConverters;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+@Data
+@ConfigurationProperties("jwt")
+public class JwtConfiguration {
+    String pub;
+    String key;
+
+    public RSAPublicKey getPublicKey() throws IOException {
+        return RsaKeyConverters.x509().convert(loadClassPathResource(this.pub));
+    }
+
+    public RSAPrivateKey getPrivateKey() throws IOException {
+        return RsaKeyConverters.pkcs8().convert(loadClassPathResource(this.key));
+    }
+
+    private ByteArrayInputStream loadClassPathResource(String path) throws IOException {
+        File file = new ClassPathResource(path).getFile();
+        return new ByteArrayInputStream(Files.readAllBytes(file.toPath()));
+    }
+}

--- a/src/main/java/com/smoothstack/common/data/ConfirmEmailToken.java
+++ b/src/main/java/com/smoothstack/common/data/ConfirmEmailToken.java
@@ -1,0 +1,43 @@
+package com.smoothstack.common.data;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.smoothstack.common.exceptions.TokenInvalidException;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.oauth2.jwt.*;
+
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ConfirmEmailToken implements JwtParseable<ConfirmEmailToken> {
+    private Integer userId;
+    private Date expiry;
+
+    public ConfirmEmailToken decode(JwtDecoder decoder, String jwt) throws TokenInvalidException {
+        try {
+            Jwt token = decoder.decode(jwt);
+
+            return ConfirmEmailToken.builder()
+                    .userId(Integer.parseInt(token.getSubject()))
+                    .expiry(Date.from(token.getExpiresAt()))
+                    .build();
+        } catch (JwtException | NullPointerException | IllegalArgumentException e) {
+            throw new TokenInvalidException();
+        }
+    }
+
+    public String encode(JwtEncoder encoder) {
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(getUserId().toString())
+                .expiresAt(getExpiry().toInstant())
+                .build();
+
+        JwtEncoderParameters params = JwtEncoderParameters.from(claims);
+        return encoder.encode(params).toString();
+    }
+}

--- a/src/main/java/com/smoothstack/common/data/JwtParseable.java
+++ b/src/main/java/com/smoothstack/common/data/JwtParseable.java
@@ -1,0 +1,11 @@
+package com.smoothstack.common.data;
+
+import com.smoothstack.common.exceptions.TokenInvalidException;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+
+// Represents a data type that can be converted to/from Jwt format.
+public interface JwtParseable<T> {
+    public T decode(JwtDecoder decoder, String jwt) throws TokenInvalidException;
+    public String encode(JwtEncoder encoder);
+}

--- a/src/main/java/com/smoothstack/common/data/ResetPasswordToken.java
+++ b/src/main/java/com/smoothstack/common/data/ResetPasswordToken.java
@@ -1,0 +1,45 @@
+package com.smoothstack.common.data;
+
+import com.smoothstack.common.exceptions.TokenInvalidException;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.security.oauth2.jwt.*;
+
+import java.util.Date;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResetPasswordToken implements JwtParseable<ResetPasswordToken> {
+    private Integer userId;
+    private String confirmation;
+    private Date expiry;
+
+    public ResetPasswordToken decode(JwtDecoder decoder, String jwt) throws TokenInvalidException {
+        try {
+            Jwt token = decoder.decode(jwt);
+
+            return ResetPasswordToken.builder()
+                    .userId(Integer.parseInt(token.getSubject()))
+                    .confirmation(token.getId())
+                    .expiry(Date.from(token.getExpiresAt()))
+                    .build();
+        } catch (JwtException | NullPointerException | IllegalArgumentException e) {
+            throw new TokenInvalidException();
+        }
+    }
+
+    public String encode(JwtEncoder encoder) {
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .subject(getUserId().toString())
+                .id(getConfirmation())
+                .expiresAt(getExpiry().toInstant())
+                .build();
+
+        JwtEncoderParameters params = JwtEncoderParameters.from(claims);
+        return encoder.encode(params).toString();
+    }
+}

--- a/src/main/java/com/smoothstack/common/services/CommonLibraryTestingService.java
+++ b/src/main/java/com/smoothstack/common/services/CommonLibraryTestingService.java
@@ -10,7 +10,6 @@ package com.smoothstack.common.services;
 import com.smoothstack.common.models.*;
 import com.smoothstack.common.models.MenuItem;
 import com.smoothstack.common.repositories.*;
-import org.aspectj.weaver.ast.Or;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/smoothstack/common/services/JwtService.java
+++ b/src/main/java/com/smoothstack/common/services/JwtService.java
@@ -1,0 +1,48 @@
+package com.smoothstack.common.services;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+@Service
+@Profile("service")
+public class JwtService {
+    @Value("${jwt.public.key}")
+    RSAPublicKey publicKey;
+
+    @Value("${jwt.private.key}")
+    RSAPrivateKey privateKey;
+
+    JwtEncoder encoder;
+    JwtDecoder decoder;
+
+    public JwtService() {
+        JWK jwk = new RSAKey
+                .Builder(this.publicKey)
+                .privateKey(this.privateKey)
+                .build();
+        JWKSource<SecurityContext> source = new ImmutableJWKSet<>(new JWKSet(jwk));
+
+        encoder = new NimbusJwtEncoder(source);
+        decoder = NimbusJwtDecoder.withPublicKey(this.publicKey).build();
+    }
+
+    public JwtEncoder getEncoder() { return encoder; }
+
+    public JwtDecoder getDecoder() { return decoder; }
+}

--- a/src/main/java/com/smoothstack/common/services/JwtService.java
+++ b/src/main/java/com/smoothstack/common/services/JwtService.java
@@ -7,39 +7,31 @@ import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 
-import org.springframework.beans.factory.annotation.Value;
+import com.smoothstack.common.configuration.JwtConfiguration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
+import java.io.IOException;
 
 @Service
 @Profile("service")
 public class JwtService {
-    @Value("${jwt.public.key}")
-    RSAPublicKey publicKey;
-
-    @Value("${jwt.private.key}")
-    RSAPrivateKey privateKey;
-
     JwtEncoder encoder;
     JwtDecoder decoder;
 
-    public JwtService() {
+    public JwtService(JwtConfiguration config) throws IOException {
         JWK jwk = new RSAKey
-                .Builder(this.publicKey)
-                .privateKey(this.privateKey)
+                .Builder(config.getPublicKey())
+                .privateKey(config.getPrivateKey())
                 .build();
         JWKSource<SecurityContext> source = new ImmutableJWKSet<>(new JWKSet(jwk));
 
         encoder = new NimbusJwtEncoder(source);
-        decoder = NimbusJwtDecoder.withPublicKey(this.publicKey).build();
+        decoder = NimbusJwtDecoder.withPublicKey(config.getPublicKey()).build();
     }
 
     public JwtEncoder getEncoder() { return encoder; }

--- a/src/main/java/com/smoothstack/common/services/messaging/AwsPinpointService.java
+++ b/src/main/java/com/smoothstack/common/services/messaging/AwsPinpointService.java
@@ -1,0 +1,139 @@
+package com.smoothstack.common.services.messaging;
+
+import com.smoothstack.common.exceptions.SendMsgFailureException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.pinpoint.PinpointClient;
+import software.amazon.awssdk.services.pinpoint.model.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AwsPinpointService implements MessagingService {
+    private static final Region DEFAULT_REGION = Region.US_EAST_1;
+
+    @Value("${cloud.aws.pinpoint.appId}")
+    private String appId;
+    @Value("${cloud.aws.pinpoint.accessKeyId}")
+    private String accessKeyId;
+    @Value("${cloud.aws.pinpoint.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.pinpoint.email.from}")
+    private String emailFrom;
+    @Value("${cloud.aws.pinpoint.email.charset}")
+    private String emailCharset;
+
+    @Value("${cloud.aws.pinpoint.sms.from}")
+    private String smsFrom;
+    @Value("${cloud.aws.pinpoint.sms.msgType}")
+    private String smsMsgType;
+    @Value("${cloud.aws.pinpoint.sms.senderId}")
+    private String smsSenderId;
+
+    private AwsBasicCredentials credentials;
+    private PinpointClient client;
+
+    @Autowired
+    public AwsPinpointService() {
+        credentials = AwsBasicCredentials.create(accessKeyId, secretKey);
+        client = PinpointClient.builder().region(DEFAULT_REGION)
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    public void sendEmail(String email, String subject, String htmlBody) throws SendMsgFailureException {
+        try {
+            Map<String,AddressConfiguration> addressMap = new HashMap<>();
+            AddressConfiguration configuration = AddressConfiguration.builder()
+                    .channelType(ChannelType.EMAIL)
+                    .build();
+
+            addressMap.put(email, configuration);
+            SimpleEmailPart emailPart = SimpleEmailPart.builder()
+                    .data(htmlBody)
+                    .charset(this.emailCharset)
+                    .build() ;
+
+            SimpleEmailPart subjectPart = SimpleEmailPart.builder()
+                    .data(subject)
+                    .charset(this.emailCharset)
+                    .build() ;
+
+            SimpleEmail simpleEmail = SimpleEmail.builder()
+                    .htmlPart(emailPart)
+                    .subject(subjectPart)
+                    .build();
+
+            EmailMessage emailMessage = EmailMessage.builder()
+                    .body(htmlBody)
+                    .fromAddress(this.emailFrom)
+                    .simpleEmail(simpleEmail)
+                    .build();
+
+            DirectMessageConfiguration directMessageConfiguration = DirectMessageConfiguration.builder()
+                    .emailMessage(emailMessage)
+                    .build();
+
+            MessageRequest messageRequest = MessageRequest.builder()
+                    .addresses(addressMap)
+                    .messageConfiguration(directMessageConfiguration)
+                    .build();
+
+            SendMessagesRequest messagesRequest = SendMessagesRequest.builder()
+                    .applicationId(this.appId)
+                    .messageRequest(messageRequest)
+                    .build();
+
+            // TODO: Read data from the response
+            client.sendMessages(messagesRequest);
+        } catch (PinpointException e) {
+            System.err.println(e.awsErrorDetails().errorMessage());
+            throw new SendMsgFailureException();
+        }
+    }
+
+    public void sendSMS(String phone, String message) throws SendMsgFailureException {
+        try {
+            Map<String, AddressConfiguration> addressMap = new HashMap<>();
+
+            AddressConfiguration addConfig = AddressConfiguration.builder()
+                    .channelType(ChannelType.SMS)
+                    .build();
+
+            addressMap.put(phone, addConfig);
+
+            SMSMessage smsMessage = SMSMessage.builder()
+                    .body(message)
+                    .messageType(this.smsMsgType)
+                    .originationNumber(this.smsFrom)
+                    .senderId(this.smsSenderId)
+                    .build();
+
+            // Create a DirectMessageConfiguration object
+            DirectMessageConfiguration direct = DirectMessageConfiguration.builder()
+                    .smsMessage(smsMessage)
+                    .build();
+
+            MessageRequest msgReq = MessageRequest.builder()
+                    .addresses(addressMap)
+                    .messageConfiguration(direct)
+                    .build();
+
+            // create a  SendMessagesRequest object
+            SendMessagesRequest request = SendMessagesRequest.builder()
+                    .applicationId(appId)
+                    .messageRequest(msgReq)
+                    .build();
+
+            // TODO: Read data from the response
+            client.sendMessages(request);
+        } catch (PinpointException e) {
+            System.err.println(e.awsErrorDetails().errorMessage());
+            throw new SendMsgFailureException();
+        }
+    }
+}

--- a/src/main/java/com/smoothstack/common/services/messaging/MessagingService.java
+++ b/src/main/java/com/smoothstack/common/services/messaging/MessagingService.java
@@ -1,0 +1,10 @@
+package com.smoothstack.common.services.messaging;
+
+import com.smoothstack.common.exceptions.SendMsgFailureException;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface MessagingService {
+    void sendEmail(String email, String subject, String htmlBody) throws SendMsgFailureException, SendMsgFailureException;
+    void sendSMS(String phone, String message) throws SendMsgFailureException;
+}

--- a/src/main/java/com/smoothstack/common/services/messaging/MockMessagingService.java
+++ b/src/main/java/com/smoothstack/common/services/messaging/MockMessagingService.java
@@ -1,0 +1,14 @@
+package com.smoothstack.common.services.messaging;
+
+public class MockMessagingService implements MessagingService {
+    public void sendEmail(String email, String subject, String htmlBody) {
+        String output = String.format("MockEmail{ email: %s, subject: %s, htmlBody: %s", email, subject, htmlBody);
+        System.out.println(output);
+    }
+
+    public void sendSMS(String phone, String message) {
+        String output = String.format("MockSms{ phone: %s, message: %s }", phone, message);
+        System.out.println(output);
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=service

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -3,3 +3,4 @@ spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
 spring.datasource.username=test
 spring.datasource.password=test
 spring.datasource.driver-class-name=org.h2.Driver
+spring.profiles.active=test


### PR DESCRIPTION
JwtService and MessagingService are now available from the common library.

They use JwtConfiguration and AwsPinpointConfiguration as configuration properties that need to be filled out by the spring application. In dependent microservices this looks like:
`@ConfigurationPropertiesScan("com.smoothstack.common.configuration")`
as an annotation for your microservice application.

`jwt.key` and `jwt.pub` are classpaths (without `classpath:`) to the file containing the PEM-encoded PKCS#8 RSA keys.

`cloud.aws.pinpoint` are all the properties required to set up the Pinpoint integration. In the case that AwsPinpoint is not necessary to configure at the moment, one can configure a `MessagingService` bean using MockMessagingService as the actual implementation.